### PR TITLE
Improve logging for Orange gateway

### DIFF
--- a/core/OrangeMoneyGateway.php
+++ b/core/OrangeMoneyGateway.php
@@ -25,14 +25,23 @@ class OrangeMoneyGateway {
         }
 
         $url = $this->baseUrl . '/oauth/v2/token';
+        logMessage('Requesting new access token');
         $ch = curl_init($url);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_POST, true);
         curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query(['grant_type' => 'client_credentials']));
+
+        // Use cURL's built-in basic authentication.
+        // We still specify the content type for clarity.
         curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
         curl_setopt($ch, CURLOPT_USERPWD, $this->clientId . ':' . $this->clientSecret);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
+            'Content-Type: application/x-www-form-urlencoded'
+        ]);
         $response = curl_exec($ch);
         $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        logMessage('Token response code: ' . $code);
+        logMessage('Token response body: ' . $response);
         curl_close($ch);
         if ($code === 200) {
             $data = json_decode($response, true);
@@ -62,6 +71,8 @@ class OrangeMoneyGateway {
         ]);
         $response = curl_exec($ch);
         $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        logMessage('Init transaction code: ' . $code);
+        logMessage('Init transaction body: ' . $response);
         curl_close($ch);
         return ['status_code' => $code, 'body' => $response];
     }
@@ -85,6 +96,8 @@ class OrangeMoneyGateway {
         ]);
         $response = curl_exec($ch);
         $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        logMessage('Status check code: ' . $code);
+        logMessage('Status check body: ' . $response);
         curl_close($ch);
         return ['status_code' => $code, 'body' => $response];
     }

--- a/core/common.php
+++ b/core/common.php
@@ -23,6 +23,23 @@ function output($status, $message, $data = null, $httpCode = 200) {
     exit;
 }
 
+/**
+ * Simple helper to append messages to the gateway log file.
+ */
+function logMessage($message, $file = null) {
+    if ($file === null) {
+        $file = dirname(__DIR__) . '/gateway.log';
+    }
+    file_put_contents($file, date('Y-m-d H:i:s') . ' - ' . $message . PHP_EOL, FILE_APPEND);
+}
+
+spl_autoload_register(function ($class) {
+    $path = __DIR__ . '/' . $class . '.php';
+    if (file_exists($path)) {
+        require_once $path;
+    }
+});
+
 function validateInputs($inputData, $requiredFields) {
     foreach ($requiredFields as $field) {
         if (empty($inputData[$field])) {

--- a/endpoints/create_order.php
+++ b/endpoints/create_order.php
@@ -4,16 +4,20 @@
 require_once __DIR__ . '/../core/OrderModel.php';
 require_once __DIR__ . '/../config/database.php'; // Chemin mis à jour
 require_once __DIR__ . '/../core/common.php';
-require_once __DIR__ . '/../core/OrangeMoneyGateway.php'; // Inclure la classe OrangeMoneyGateway
+$gatewayFile = __DIR__ . '/../core/OrangeMoneyGateway.php';
+if (file_exists($gatewayFile)) {
+    require_once $gatewayFile;
+} else {
+    logMessage('Gateway file missing: ' . $gatewayFile);
+}
+if (!class_exists('OrangeMoneyGateway')) {
+    logMessage('OrangeMoneyGateway class not found after include');
+}
 $omConfig = include __DIR__ . '/../config/orange_money.php'; // Charger la configuration Orange Money
 $env = include __DIR__ . '/../env.php';
 
 // Valider la clé API avant de traiter la requête
 validateApiKey();
-
-function logMessage($message) {
-    file_put_contents('gateway.log', date('Y-m-d H:i:s') . " - " . $message . "\n", FILE_APPEND);
-}
 
 // La logique de routage est maintenant dans index.php, ce fichier est un handler spécifique
 // Donc, la fonction handleCreateOrder est appelée directement.
@@ -53,7 +57,8 @@ function handleCreateOrder() {
     $orangeRes = $omGateway->initTransaction($payload);
     $orangeData = json_decode($orangeRes['body'], true);
 
-    logMessage("Orange Response: " . json_encode($orangeData));
+    logMessage("Orange Response Code: " . $orangeRes['status_code']);
+    logMessage("Orange Response Body: " . json_encode($orangeData));
 
     if ($orangeRes['status_code'] !== 201 || !isset($orangeData['payment_url'])) {
         output('error', 'Orange payment initiation failed: ' . ($orangeData['message'] ?? 'Unknown error'), null, 500);

--- a/index.php
+++ b/index.php
@@ -10,7 +10,14 @@
  */
 define('ROOTDIR', __DIR__);
 
-require_once ROOTDIR . '/core/common.php';
+require_once __DIR__ . '/core/common.php';
+
+// Double-check that core functions are loaded
+if (!function_exists('validateApiKey')) {
+    // If the function is missing, attempt to load again and log the issue
+    require_once __DIR__ . '/core/common.php';
+    error_log('validateApiKey function missing after include of common.php');
+}
 $apiKeys = include ROOTDIR . '/config/api_keys.php';
 require_once ROOTDIR . '/env.php'; // Charger les variables d'environnement
 


### PR DESCRIPTION
## Summary
- centralize logMessage helper
- log OAuth token fetch details
- log transaction request/response codes
- include response codes in order creation logs
- autoload classes and log missing gateway file
- check common file load in index

## Testing
- `php -l core/OrangeMoneyGateway.php`
- `php -l endpoints/create_order.php`
- `php -l core/common.php`
- `find . -maxdepth 2 -name '*.php' -print | xargs -I{} php -l {}`


------
https://chatgpt.com/codex/tasks/task_e_6873df35a4548327a8a2afc26e5c4282